### PR TITLE
fix typo?

### DIFF
--- a/input/fsh/terminology.fsh
+++ b/input/fsh/terminology.fsh
@@ -1,6 +1,6 @@
 Alias: $SCT = http://snomed.info/sct
 Alias: $LNC = http://loinc.org
-Alias: $ICD11 = http://id.who.int/icd11/mms
+Alias: $ICD11 = http://icd.who.int/icd11/mms
 Alias: $RXN = http://www.nlm.nih.gov/research/umls/rxnorm
 
 ValueSet: VSPresentation


### PR DESCRIPTION
in terminology aliases, there is 
`$ICD11 = http://id.who.int/icd11/mms`
I believe it is 
`$ICD11 = http://icd.who.int/icd11/mms`
@rmrlangford 